### PR TITLE
feat: switch heading font from Fraunces to Source Serif 4

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -118,7 +118,7 @@ body {
 
 @theme inline {
   /* Fonts loaded via next/font/google in src/app/layout.tsx */
-  --font-display: var(--font-fraunces), Georgia, serif;
+  --font-display: var(--font-source-serif), Georgia, serif;
   --font-body: var(--font-nunito-sans), system-ui, sans-serif;
   --font-sans: var(--font-nunito-sans), system-ui, sans-serif; /* default override */
   --font-mono: ui-monospace, SFMono-Regular, monospace;
@@ -172,9 +172,9 @@ body {
     @apply bg-background text-foreground font-sans leading-relaxed;
   }
   
-  /* Typography - Headings with Fraunces (display font) */
+  /* Typography - Headings with Source Serif 4 (display font) */
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-fraunces), Georgia, serif;
+    font-family: var(--font-source-serif), Georgia, serif;
     font-weight: 600;
     color: hsl(var(--foreground));
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Fraunces, Nunito_Sans } from 'next/font/google';
+import { Source_Serif_4, Nunito_Sans } from 'next/font/google';
 import './globals.css';
 import { APP_DOMAIN } from '@/lib/constants';
 import { CookiesProvider } from 'next-client-cookies/server';
@@ -15,12 +15,12 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
 import React from 'react';
 
-// Display font for headlines, prices and hero text (mapped to font-display via --font-display)
-const fraunces = Fraunces({
+// Display font for headlines, prices and hero text (mapped to font-display via --font-source-serif)
+const sourceSerif = Source_Serif_4({
   subsets: ['latin'],
   weight: ['600', '700'],
   style: ['normal', 'italic'],
-  variable: '--font-fraunces',
+  variable: '--font-source-serif',
   display: 'swap',
 });
 // Body/UI font (mapped to font-body and the font-sans default via --font-body)
@@ -47,7 +47,7 @@ export default async function RootLayout({
 
   return (
     <html
-      className={`${fraunces.variable} ${nunitoSans.variable} notranslate bg-background`}
+      className={`${sourceSerif.variable} ${nunitoSans.variable} notranslate bg-background`}
       translate="no"
     >
       <head>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,10 +20,10 @@ const config = {
     },
     extend: {
       fontFamily: {
-        display: ['var(--font-fraunces)', 'Georgia', 'serif'],
+        display: ['var(--font-source-serif)', 'Georgia', 'serif'],
         body: ['var(--font-nunito-sans)', 'system-ui', 'sans-serif'],
         sans: ['var(--font-nunito-sans)', 'system-ui', 'sans-serif'], // default override
-        serif: ['var(--font-fraunces)', 'Georgia', 'serif'], // legacy alias for display
+        serif: ['var(--font-source-serif)', 'Georgia', 'serif'], // legacy alias for display
         mono: ['ui-monospace', 'SFMono-Regular', 'monospace'],
       },
       colors: {


### PR DESCRIPTION
Fraunces' decorative descenders (e.g. the swashed "j"/"g" from the WONK axis) drew consistent negative feedback. Source Serif 4 is a calm, conventional yet warm editorial serif: variable, OFL, available via next/font/google, broad Latin-Extended coverage, and pairs cleanly with the Nunito Sans body.

- layout.tsx: Source_Serif_4 (weights 600/700 + italic); CSS var --font-fraunces -> --font-source-serif
- globals.css + tailwind.config.ts: font-display / font-serif now resolve to --font-source-serif (Nunito Sans body unchanged)