### PR TITLE
feat: gallery polish (lightbox spinner, thumbnail fades) + reorder bo…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,15 @@ body {
   .text-balance {
     text-wrap: balance;
   }
+
+  /* Hide the horizontal scrollbar (e.g. for the product gallery thumbnail strip). */
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 /* Design Tokens for Pattern Paradise - Warm, Handmade, Modern-Editorial */

--- a/src/components/bottom-navigation.tsx
+++ b/src/components/bottom-navigation.tsx
@@ -9,11 +9,13 @@ import { usePreview } from '@/app/providers/PreviewFlagProvider';
 import { useValidSession } from '@/hooks/useValidSession';
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
 
+// Order groups related destinations: Home + Search on the left, Sell + Profile on
+// the right, with the featured Swipe action kept in the centre.
 const menuItems = [
-  { id: 'shop', label: 'Shop', icon: House, href: '/' },
-  { id: 'sell', label: 'Sell', icon: DollarSign, href: '/app/secure/sell' },
+  { id: 'shop', label: 'Home', icon: House, href: '/' },
+  { id: 'browse', label: 'Search', icon: Search, href: '/browse' },
   { id: 'swipe', label: 'Swipe', icon: Heart, href: '/swipe', featured: true },
-  { id: 'browse', label: 'Browse', icon: Search, href: '/browse' },
+  { id: 'sell', label: 'Sell', icon: DollarSign, href: '/app/secure/sell' },
   { id: 'me', label: 'Me', icon: User, href: '/app/secure/auth/me' },
 ];
 

--- a/src/lib/components/ProductGallery/Lightbox.tsx
+++ b/src/lib/components/ProductGallery/Lightbox.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { CldImage } from 'next-cloudinary';
 import { Carousel, CarouselContent, CarouselItem, type CarouselApi } from '@/components/ui/carousel';
 import { X, ChevronLeft, ChevronRight } from 'lucide-react';
+import { LoadingSpinnerComponent } from '@/components/loading-spinner';
 
 interface ProductLightboxProps {
   imageUrls: string[];
@@ -25,6 +26,7 @@ export default function ProductLightbox({
 }: ProductLightboxProps) {
   const [api, setApi] = useState<CarouselApi>();
   const [selected, setSelected] = useState(startIndex);
+  const [loaded, setLoaded] = useState<Record<string, boolean>>({});
 
   const hasMultiple = imageUrls.length > 1;
 
@@ -82,14 +84,24 @@ export default function ProductLightbox({
           <CarouselContent>
             {imageUrls.map((src) => (
               <CarouselItem key={src} className="flex items-center justify-center">
-                <CldImage
-                  src={src}
-                  alt={alt}
-                  width={1400}
-                  height={1750}
-                  format="webp"
-                  className="h-auto max-h-[86vh] w-auto max-w-[92vw] rounded-lg object-contain"
-                />
+                <div className="relative flex min-h-[50vh] items-center justify-center">
+                  {!loaded[src] ? (
+                    <span className="absolute inset-0 flex items-center justify-center">
+                      <LoadingSpinnerComponent className="text-background" />
+                    </span>
+                  ) : null}
+                  <CldImage
+                    src={src}
+                    alt={alt}
+                    width={1400}
+                    height={1750}
+                    format="webp"
+                    onLoad={() => setLoaded((prev) => ({ ...prev, [src]: true }))}
+                    className={`h-auto max-h-[86vh] w-auto max-w-[92vw] rounded-lg object-contain transition-opacity duration-300 ${
+                      loaded[src] ? 'opacity-100' : 'opacity-0'
+                    }`}
+                  />
+                </div>
               </CarouselItem>
             ))}
           </CarouselContent>

--- a/src/lib/components/ProductGallery/index.tsx
+++ b/src/lib/components/ProductGallery/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { CldImage } from 'next-cloudinary';
 import { Carousel, CarouselContent, CarouselItem, type CarouselApi } from '@/components/ui/carousel';
 import { Maximize2 } from 'lucide-react';
@@ -49,11 +49,38 @@ export default function ProductGallery({
     setLightboxOpen(true);
   }, []);
 
+  const hasMultiple = imageUrls.length > 1;
+
+  // Track whether the thumbnail strip can scroll further left/right so we can
+  // show a soft fade indicator on each scrollable side (and hide it at the edges).
+  const thumbsRef = useRef<HTMLDivElement>(null);
+  const [edges, setEdges] = useState({ left: false, right: false });
+  const updateEdges = useCallback(() => {
+    const el = thumbsRef.current;
+    if (!el) return;
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    setEdges({
+      left: scrollLeft > 1,
+      right: scrollLeft + clientWidth < scrollWidth - 1,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!hasMultiple) return;
+    updateEdges();
+    const el = thumbsRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', updateEdges, { passive: true });
+    window.addEventListener('resize', updateEdges);
+    return () => {
+      el.removeEventListener('scroll', updateEdges);
+      window.removeEventListener('resize', updateEdges);
+    };
+  }, [hasMultiple, updateEdges, imageUrls.length]);
+
   const altText = `${title} in ${category}${
     subCategories?.length ? ` – styles: ${subCategories.join(', ')}` : ''
   } on Pattern Paradise`;
-
-  const hasMultiple = imageUrls.length > 1;
 
   return (
     <div className="flex flex-col gap-3">
@@ -103,30 +130,51 @@ export default function ProductGallery({
         </div>
       ) : null}
 
-      {/* Thumbnail strip — horizontally scrollable so many images never overflow */}
+      {/* Thumbnail strip — horizontally scrollable (no visible scrollbar); soft
+          fade hints when there are more images off-screen left/right. The py-1
+          keeps the active thumbnail's 2px ring from being clipped. */}
       {hasMultiple ? (
-        <div className="-mx-1 flex snap-x gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:thin]">
-          {imageUrls.map((src, index) => (
-            <button
-              key={src}
-              type="button"
-              onClick={() => openLightbox(index)}
-              aria-label={`Open image ${index + 1} fullscreen`}
-              className={cn(
-                'relative h-16 w-16 shrink-0 snap-start overflow-hidden rounded-lg ring-2 transition-all sm:h-20 sm:w-20',
-                index === selected ? 'ring-primary' : 'ring-transparent hover:ring-border',
-              )}
-            >
-              <CldImage
-                src={src}
-                alt=""
-                fill
-                format="webp"
-                sizes="80px"
-                className="object-cover"
-              />
-            </button>
-          ))}
+        <div className="relative">
+          <div
+            ref={thumbsRef}
+            className="no-scrollbar flex snap-x gap-2 overflow-x-auto px-0.5 py-1"
+          >
+            {imageUrls.map((src, index) => (
+              <button
+                key={src}
+                type="button"
+                onClick={() => openLightbox(index)}
+                aria-label={`Open image ${index + 1} fullscreen`}
+                className={cn(
+                  'relative h-16 w-16 shrink-0 snap-start overflow-hidden rounded-lg ring-2 transition-all sm:h-20 sm:w-20',
+                  index === selected ? 'ring-primary' : 'ring-transparent hover:ring-border',
+                )}
+              >
+                <CldImage
+                  src={src}
+                  alt=""
+                  fill
+                  format="webp"
+                  sizes="80px"
+                  className="object-cover"
+                />
+              </button>
+            ))}
+          </div>
+          <div
+            aria-hidden
+            className={cn(
+              'pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-background to-transparent transition-opacity duration-200',
+              edges.left ? 'opacity-100' : 'opacity-0',
+            )}
+          />
+          <div
+            aria-hidden
+            className={cn(
+              'pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent transition-opacity duration-200',
+              edges.right ? 'opacity-100' : 'opacity-0',
+            )}
+          />
         </div>
       ) : null}
 


### PR DESCRIPTION
…ttom nav

Product gallery:
- Lightbox now shows a centered spinner per image until it loads, then fades the image in (covers swiping to not-yet-loaded images)
- Thumbnail strip hides its horizontal scrollbar (new .no-scrollbar utility) and shows a soft fade on each side only while more images exist that way (disappears at the edges, via scroll/resize detection)
- Added vertical padding so the active thumbnail's 2px ring is no longer clipped

Bottom navigation reordered to Home · Search · Swipe (featured, centered) · Sell · Profile, grouping Home+Search and Sell+Profile.